### PR TITLE
Stop talking in quotes, typo-fixes

### DIFF
--- a/Mods/Alpha36/A36BonusMod/creatures.txt
+++ b/Mods/Alpha36/A36BonusMod/creatures.txt
@@ -914,7 +914,7 @@
         pluralName = "centaurs"
 	    firstNameGen = "FIRST_FEMALE"
       }
-      chatReactionFriendly = "\"curses all greenskins\""
+      chatReactionFriendly = "curses all greenskins"
       chatReactionHostile = "\"Die!\""
       inventory = {
         {  "ElvenSword"}
@@ -951,7 +951,7 @@
         pluralName = "Centaurs"
 	    firstNameGen = "FIRST_MALE"
       }
-      chatReactionFriendly = "\"talks about farming\""
+      chatReactionFriendly = "talks about farming"
       chatReactionHostile = "\"Stay Back!\""
 	  inventory = {
         {  "FirstAidKit" 1 1 0.1}
@@ -980,7 +980,7 @@
         pluralName = "Centaurs"
     	firstNameGen = "FIRST_FEMALE"
       }
-      chatReactionFriendly = "\"talks about methods of trackings animals\""
+      chatReactionFriendly = "talks about methods of tracking animals"
       chatReactionHostile = "\"Die!\""
       inventory = {
         {  "Bow"}
@@ -1025,7 +1025,7 @@
         pluralName = "Centaurs"
     	firstNameGen = "FIRST_FEMALE"
       }
-      chatReactionFriendly = "\"talks about centaur religion\""
+      chatReactionFriendly = "talks about centaur religion"
       chatReactionHostile = "\"Die!\""
       inventory = {
         { type =  "IronStaff" prefixChance = 0.3}
@@ -1051,7 +1051,7 @@
         name = "centaur child"
         pluralName = "centaur children"
       }
-      chatReactionFriendly = "\"talks about playing in the fields\""
+      chatReactionFriendly = "talks about playing in the fields"
       chatReactionHostile = "\"Don't hurt me!\""
 	  inventory = {
         {  "FirstAidKit" 1 1 0.1}
@@ -1075,7 +1075,7 @@
         pluralName = "Centaurs"
 	    firstNameGen = "FIRST_MALE"
       }
-      chatReactionFriendly = "\"curses all greenskin invaders\""
+      chatReactionFriendly = "curses all greenskin invaders"
       chatReactionHostile = "\"Die!\""
       deathDescription = "slain"
       inventory = {
@@ -1112,8 +1112,8 @@
         pluralName = "Centaurs"
 	    firstNameGen = "FIRST_MALE"
       }
-      chatReactionFriendly = "\"talks about slaying greenskins\""
-      chatReactionHostile = "\"Perish Fiend!\""
+      chatReactionFriendly = "talks about slaying greenskins"
+      chatReactionHostile = "\"Perish, Fiend!\""
       inventory = {
         {  "Sword" }
         {  "ChainArmor" }
@@ -1189,7 +1189,7 @@
         pluralName = "amazons"
         firstNameGen = "FIRST_FEMALE"
       }
-      chatReactionFriendly = "\"talks about her god's many blessings\""
+      chatReactionFriendly = "talks about her gods' many blessings"
       chatReactionHostile = "\"Die, fiend!\""
       inventory = {
         {  "Sword"}
@@ -1228,7 +1228,7 @@
         pluralName = "amazons"
         firstNameGen = "FIRST_FEMALE"
       }
-      chatReactionFriendly = "\"talks about tracking prey\""
+      chatReactionFriendly = "talks about tracking prey"
       chatReactionHostile = "\"Die, fiend!\""
       inventory = {
         {  "ElvenBow"}
@@ -1265,7 +1265,7 @@
 	  	  permanentEffects = {
 		RIDER 1
       }
-      chatReactionFriendly = "\"talks about honoring the gods.\""
+      chatReactionFriendly = "talks about honoring the gods."
       chatReactionHostile = "\"Die, cretin!\""
       inventory = {
         { type =  "BattleAxe" prefixChance = 0.1 }
@@ -1316,7 +1316,7 @@
         pluralName = "amazons"
         firstNameGen = "FIRST_FEMALE"
       }
-      chatReactionFriendly = "\"talks about legends of old.\""
+      chatReactionFriendly = "talks about legends of old."
       chatReactionHostile = "\"Die, fiend!\""
       inventory = {
         { type =  "Robe" prefixChance = 1}
@@ -1360,7 +1360,7 @@
         pluralName = "amazons"
         firstNameGen = "FIRST_FEMALE"
       }
-      chatReactionFriendly = "\"complains about the teachings of the elders\""
+      chatReactionFriendly = "complains about the teachings of the elders"
       chatReactionHostile = "\"Die, fiend!\""
       inventory = {
 
@@ -1403,7 +1403,7 @@
         pluralName = "amazons"
         firstNameGen = "FIRST_FEMALE"
       }
-      chatReactionFriendly = "\"talks about combat training\""
+      chatReactionFriendly = "talks about combat training"
       chatReactionHostile = "\"Die!\""
       inventory = {
         {  "ElvenSword"}
@@ -1460,7 +1460,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about flying through clouds\""
+      chatReactionFriendly = "talks about flying through clouds"
       chatReactionHostile = "\"Don't mess with Air Fairies!\""
     }
     "DARK_FAIRY" inherit "AIR_FAIRY"
@@ -1479,7 +1479,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about the all-consuming void of darkness\""
+      chatReactionFriendly = "talks about the all-consuming void of darkness"
       chatReactionHostile = "\"The shadows will consume you!\""
     }
     "DEMON_FAIRY" inherit "AIR_FAIRY"
@@ -1505,7 +1505,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about not wanting to become a succubus\""
+      chatReactionFriendly = "talks about not wanting to become a succubus"
       chatReactionHostile = "\"Die, Whelp!\""
     }
     "EARTH_FAIRY" inherit "AIR_FAIRY"
@@ -1529,7 +1529,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about different kinds of metals\""
+      chatReactionFriendly = "talks about different kinds of metals"
       chatReactionHostile = "\"Don't mess with Earth Fairies!\""
     }
     "ELECTRIC_FAIRY" inherit "AIR_FAIRY"
@@ -1546,7 +1546,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about shocking people\""
+      chatReactionFriendly = "talks about shocking people"
       chatReactionHostile = "\"Get Zapped!\""
     }
     "FIRE_FAIRY" inherit "AIR_FAIRY"
@@ -1582,7 +1582,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about burning things\""
+      chatReactionFriendly = "talks about burning things"
       chatReactionHostile = "\"BURN!\""
     }
     "LIGHT_FAIRY" inherit "AIR_FAIRY"
@@ -1599,7 +1599,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about helping people\""
+      chatReactionFriendly = "talks about helping people"
       chatReactionHostile = "\"I will smite you!\""
     }
     "MAGIC_FAIRY" inherit "AIR_FAIRY"
@@ -1621,7 +1621,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about good tricks to play on people\""
+      chatReactionFriendly = "talks about good tricks to play on people"
       chatReactionHostile = "\"Don't mess with Magic Fairies!\""
     }
     "NATURE_FAIRY" inherit "AIR_FAIRY"
@@ -1642,7 +1642,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about growing plants\""
+      chatReactionFriendly = "talks about growing plants"
       chatReactionHostile = "\"Don't mess with Nature Fairies!\""
     }
     "WATER_FAIRY" inherit "AIR_FAIRY"
@@ -1672,7 +1672,7 @@
         pluralName = "fairies"
         firstNameGen = "PIXIE"
       }
-      chatReactionFriendly = "\"talks about fish and other water animals\""
+      chatReactionFriendly = "talks about fish and other water animals"
       chatReactionHostile = "\"Drown, fairy hater!\""
     }
     "FAIRY_QUEEN"
@@ -1721,7 +1721,7 @@
         name = "Goddess Illusia"
         pluralName = "fairies"
       }
-      chatReactionFriendly = "\"talks about ancient fae magic\""
+      chatReactionFriendly = "talks about ancient fae magic"
       chatReactionHostile = "\"Magic consume you!\""
       inventory = {
 
@@ -1779,8 +1779,8 @@
         name = "Illusia's Illusion"
         pluralName = "fairies"
       }
-      chatReactionFriendly = "\"talks in the ancient spirit language.\""
-      chatReactionHostile = "\"talks in the ancient spirit language angrily.\"" 
+      chatReactionFriendly = "talks in the ancient spirit language."
+      chatReactionHostile = "talks in the ancient spirit language angrily." 
     }
     "FAIRY_QUEEN_ILLUSION_2"
     {
@@ -1815,8 +1815,8 @@
         name = "Illusia's Illusion"
         pluralName = "fairies"
       }
-      chatReactionFriendly = "\"talks in the ancient spirit language.\""
-      chatReactionHostile = "\"talks in the ancient spirit language angrily.\"" 
+      chatReactionFriendly = "talks in the ancient spirit language."
+      chatReactionHostile = "talks in the ancient spirit language angrily." 
     }
 	
 #---------------------------------------------------------
@@ -2553,8 +2553,8 @@
       name = {
         name = "banshee"
       }
-      chatReactionFriendly = "\"sobs uncontrollably\""
-      chatReactionHostile = "\"screams in an ear-shattering pitch\""
+      chatReactionFriendly = "sobs uncontrollably"
+      chatReactionHostile = "screams in an ear-shattering pitch"
     }
     "B_GARGOYLE"
     {
@@ -2616,8 +2616,8 @@
         name = "giant"
         firstNameGen = "CYCLOPS"
       }
-      chatReactionFriendly = "\"talks about annoying small people\""
-      chatReactionHostile = "\"makes angry giant noises\""
+      chatReactionFriendly = "talks about annoying small people"
+      chatReactionHostile = "makes angry giant noises"
       inventory = {
         {  "HeavyClub" }
         {  "GoldPiece" 30 50 }
@@ -2701,7 +2701,7 @@
         name = "hobgoblin"
         firstNameGen = "ORC"
       }
-      chatReactionFriendly = "\"complains about other greenskins\""
+      chatReactionFriendly = "complains about other greenskins"
       chatReactionHostile = "\"Die!\""
       inventory = {
         {  "Spear"}
@@ -2752,7 +2752,7 @@
         name = "ogre"
         firstNameGen = "ORC_FEMALE"
       }
-      chatReactionFriendly = "\"complains about ogre males\""
+      chatReactionFriendly = "complains about ogre males"
       chatReactionHostile = "\"Die!\""
 	}
 	"ORC_PRIMARCH_TRIBE"
@@ -2789,7 +2789,7 @@
       maxLevelIncrease = {
         MELEE 3
 	}
-      chatReactionFriendly = "\"talks about inner-tribal relations\""
+      chatReactionFriendly = "talks about inter-tribal relations"
       chatReactionHostile = "\"Die!\""
       inventory = {
         { type =  "InfBattleAxe" prefixChance = 0.2 }
@@ -2831,7 +2831,7 @@
       maxLevelIncrease = {
         MELEE 4
 	}
-      chatReactionFriendly = "\"talks about training underlings\""
+      chatReactionFriendly = "talks about training underlings"
       chatReactionHostile = "\"Die!\""
       inventory = {
         { type =  "BattleAxe" prefixChance = 0.05 chance = 0.5 }
@@ -2876,7 +2876,7 @@
 	permanentEffects = {
 		RIDER 1
       }
-      chatReactionFriendly = "\"talks about fighting\""
+      chatReactionFriendly = "talks about fighting"
       chatReactionHostile = "\"Die!\""
       inventory = {
         { type =  "Mace" prefixChance = 0.05 chance = 0.5 }
@@ -2917,7 +2917,7 @@
       maxLevelIncrease = {
         MELEE 9
 	}
-      chatReactionFriendly = "\"talks about fighting\""
+      chatReactionFriendly = "talks about fighting"
       chatReactionHostile = "\"Die!\""
       inventory = {
         {  "BattleAxe"}
@@ -2956,7 +2956,7 @@
       maxLevelIncrease = {
         MELEE 9
 	}
-      chatReactionFriendly = "\"talks about fighting\""
+      chatReactionFriendly = "talks about fighting"
       chatReactionHostile = "\"Die!\""
       inventory = {
         { type =  "HeavyClub" prefixChance = 0.05 }
@@ -3013,7 +3013,7 @@
         name = "orc"
         firstNameGen = "ORC_FEMALE"
       }
-      chatReactionFriendly = "\"complains about orc males\""
+      chatReactionFriendly = "complains about orc males"
       chatReactionHostile = "\"Die!\""
     }
     "POSSESSED_BOOK"
@@ -3052,8 +3052,8 @@
       name = {
         name = "spell book"
       }
-      chatReactionFriendly = "\"floats around eerily\""
-      chatReactionHostile = "\"Flips its pages angrily\""
+      chatReactionFriendly = "floats around eerily"
+      chatReactionHostile = "flips its pages angrily"
       deathDescription = "destroyed"
     }
 "WOLF_WARRIOR"
@@ -3152,7 +3152,7 @@
         name = "shard spitter"
       }
       chatReactionFriendly = "\"Guuuh...?\""
-      chatReactionHostile = "\"prepares to spit a rock at your face\""
+      chatReactionHostile = "prepares to spit a rock at your face"
     }
     "SPRITE"
     {
@@ -3181,8 +3181,8 @@
       name = {
         name = "sprite"
       }
-      chatReactionFriendly = "\"talks too quietly for you to hear\""
-      chatReactionHostile = "\"it flutters around agrily\""
+      chatReactionFriendly = "talks too quietly for you to hear"
+      chatReactionHostile = "flutters around angrily"
       deathDescription = "swatted"
       noChase = true
     }
@@ -3263,7 +3263,7 @@
         name = "bengal tiger"
       }
       chatReactionFriendly = "\"puuurrrr...\""
-      chatReactionHostile = "\"roars at you.\""
+      chatReactionHostile = "roars at you."
     }
     "ELEPHANT"
     {
@@ -3290,8 +3290,8 @@
       name = {
         name = "elephant"
       }
-      chatReactionFriendly = "\"it says nothing, elephants can't talk\""
-      chatReactionHostile = "\"looks like it might charge you\""
+      chatReactionFriendly = "\"It says nothing, elephants can't talk\""
+      chatReactionHostile = "looks like it might charge you"
       noChase = true
     }
     "LION"
@@ -3318,7 +3318,7 @@
         name = "lion"
       }
       chatReactionFriendly = "\"puuurrrr...\""
-      chatReactionHostile = "\"roars aggresively\""
+      chatReactionHostile = "roars aggresively"
     }
     "LIONESS"
     {
@@ -3346,7 +3346,7 @@
         pluralName = "Lionesses"
       }
       chatReactionFriendly = "\"puuurrrr...\""
-      chatReactionHostile = "\"roars angrily at you\""
+      chatReactionHostile = "roars angrily at you"
     }
     "CROCODILE"
     {
@@ -3372,8 +3372,8 @@
       name = {
         name = "crocodile"
       }
-      chatReactionFriendly = "\"it says nothing, crocodiles can't talk\""
-      chatReactionHostile = "\"looks like it'll bite you.\""
+      chatReactionFriendly = "\"It says nothing. Crocodiles can't talk.\""
+      chatReactionHostile = "looks like it'll bite you"
     }
     "WARRIOR_HERO"
     {
@@ -3735,8 +3735,8 @@
       name = {
         name = "ocean portal"
       }
-      chatReactionFriendly = "\"Water is constantly being shot at an immense pressure from inside the portal. \""
-      chatReactionHostile = "\"Water is constantly being shot at an immense pressure from inside the portal.\""
+      chatReactionFriendly = "\"Water is constantly being shot, at an immense pressure, from inside the portal. \""
+      chatReactionHostile = "\"Water is constantly being shot, at an immense pressure, from inside the portal.\""
       deathDescription = "destroyed"
     }
     "ADOXIE_EYE" 
@@ -3780,8 +3780,8 @@
         name = "Adoxie's eye"
         pluralName = "eyes"
       }
-      chatReactionFriendly = "\"nothing, why did you think an eye could talk?\""
-      chatReactionHostile = "\"nothing, why did you think an eye could talk?\""
+      chatReactionFriendly = "nothing, why did you think an eye could talk?"
+      chatReactionHostile = "nothing, why did you think an eye could talk?"
       deathDescription = "destroyed"
     }
    "ADOXIE_HEAD_PLAYER" inherit "ADOXIE_HEAD" {
@@ -7228,8 +7228,8 @@
 	  name = {
         name = "shade"
 	  }
-      chatReactionFriendly = "\"it screeches in a horrid voice\""
-      chatReactionHostile = "\"it screeches in a horrid voice\""
+      chatReactionFriendly = "screeches in a horrid voice"
+      chatReactionHostile = "it screeches in a horrid voice"
 	  cantEquip = true
       spells = { "rapid invisibility" }
       permanentEffects = {


### PR DESCRIPTION
Chat responses in the double sets of quotes & slash are rendered verbatim: "This is what's between my quote marks with slashes!".  Chat responses that are more genericized only need single quotes and append the creature's name before it: "KA101 talks about proofreading code."

Fixed a few typos as well.