### PR TITLE
Update items.txt

### DIFF
--- a/Mods/Alpha36/A36BonusMod/items.txt
+++ b/Mods/Alpha36/A36BonusMod/items.txt
@@ -290,7 +290,6 @@ End
     resourceId = "CROPS"
     weight = 5
     storageIds = {"resources"}
-    effect = { Lasting SATIATED }
    }
 
 


### PR DESCRIPTION
Striking the line does prevent creatures from carrying off and eating the crops, at least in a small-scale test.

Possible side-effect: imps tended the crop field and didn't recognize trees targeted for cutting, until I targeted soft-rock for mining (the imp that mined then cut the trees too).