### PR TITLE
Update items.txt

### DIFF
--- a/Mods/Alpha36/A36BonusMod/items.txt
+++ b/Mods/Alpha36/A36BonusMod/items.txt
@@ -65,7 +65,6 @@ Def MAGIC_WEAPON_PREFIXES()
       1 LastingEffect COLD_VULNERABILITY
       1 LastingEffect ACID_VULNERABILITY
       1 LastingEffect MAGIC_VULNERABILITY
-      1 LastingEffect SLEEP
       1 LastingEffect PANIC
       1 JoinPrefixes { ItemAttrBonus SPELL_DAMAGE 20 AttackerEffect Suicide DIE }
 	}


### PR DESCRIPTION
Deletes LastingEffect SLEEP from magic weapons.  As applied to an iron staff, it keeps the wielder asleep indefinitely and prevents anyone from removing the staff without killing the wielder.

Not acceptable for something that creatures might auto-equip.