### PR TITLE
KA101 combat clawback

### DIFF
--- a/Mods/Alpha36/A36BonusMod/keeper_creatures.txt
+++ b/Mods/Alpha36/A36BonusMod/keeper_creatures.txt
@@ -7,7 +7,7 @@
 
 "2_dark_knight" modify {
     immigrantGroups = append {"dark_knight_modded" "neutral_allies" "dark_allies_extended" }
-    technology = append { "simplistic animations" "magic contraptions" "rock blast" }
+    technology = append { "simplistic animations" "magic contraptions" "rock blast" "combat succubus" }
     initialTech = { "iron working" }
     workshopGroups = append { "basic_Bonus_Mod"   "techBooks" }
     description = "(Challenge) The dark knight keeper is better at melee combat but worse at spell casting."
@@ -16,7 +16,7 @@
 #Dark mages come after dark knights as sometimes bits of the GUI get duplicated the other way round.
 "1_dark_mage" modify {
     immigrantGroups = append {"dark_keeper_modded" "neutral_allies" "dark_allies_extended" }
-    technology = append { "simplistic animations" "magic contraptions" "dragon taming" "demonic alliance" "rock blast"}
+    technology = append { "simplistic animations" "magic contraptions" "dragon taming" "demonic alliance" "rock blast" "combat succubus"}
     workshopGroups = append { "basic_Bonus_Mod" "techBooks" }
 	credit = { "WOOD" 2000 "STONE" 10 "IRON" 10 "ADA" 5 "CROPS" 25 }
   }

--- a/Mods/Alpha36/A36BonusMod/technology.txt
+++ b/Mods/Alpha36/A36BonusMod/technology.txt
@@ -46,7 +46,7 @@
   "demonic alliance"         { "Summon a demon lord through your dungeon portal. [Also requires throne]"     {"demonology"}}
   "minotaur mutation"        { "Give birth to a minotaur. [Also requires pregnancy]"                         {"beast mutation"}}
   "cyclops mutation"         { "Give birth to a cyclops. [Also requires pregnancy]"                          {"humanoid mutation"}}
-  "combat succubus"          { "Enable the newly recruited sucubbi to do combat."                            {"demonology"}}
+  "combat succubus"          { "Enable the newly recruited succubi to do combat."                            {"demonology"}}
 #Hard mode
   "absorbtion"               { "Gain dopplegangers."                                          {"demonology" "beast mutation"}}
 #Necromancer


### PR DESCRIPTION
This reenables combat succubae for Evil Human keepers and fixes a typo in their tech entry.

I've got a sprite hack but since it's just Pie's with a haircut & eye/clothing palette-swap, will hold off.