### PR TITLE
Rebalance Venorack armor

### DIFF
--- a/Mods/Alpha36/A36BonusMod/items.txt
+++ b/Mods/Alpha36/A36BonusMod/items.txt
@@ -1051,7 +1051,7 @@ End
     weight = 12
     price = 100
     modifiers = {
-      DEFENSE 4
+      DEFENSE 5
     }
     genPrefixes = {
       1 ItemAttrBonus DEFENSE 3
@@ -1061,7 +1061,7 @@ End
 			LastingEffect BLIND
 		}
     }
-    maxUpgrades = 2
+    maxUpgrades = 1
 	equipedEffect = { POISON_RESISTANT }
 	storageIds = {"equipment"}
   }
@@ -1076,14 +1076,14 @@ End
     weight = 2
     price = 30
     modifiers = {
-      DEFENSE 1
+      DEFENSE 2
     }
     genPrefixes = {
       1 LastingEffect FLYING
       1 LastingEffect FIRE_RESISTANT
       3 ItemAttrBonus DEFENSE 3
     }
-    maxUpgrades = 2
+    maxUpgrades = 1
 	equipedEffect = { POISON_RESISTANT }
 	storageIds = {"equipment"}
   }
@@ -1098,13 +1098,13 @@ End
     weight = 0.8
     price = 30
     modifiers = {
-      DEFENSE 1
+      DEFENSE 2
     }
     genPrefixes = {
       1 ItemAttrBonus DAMAGE 3
       1 ItemAttrBonus SPELL_DAMAGE 3
     }
-    maxUpgrades = 2
+    maxUpgrades = 1
 	equipedEffect = { POISON_RESISTANT }
 	storageIds = {"equipment"}
   }
@@ -1125,7 +1125,7 @@ End
       1 LastingEffect TELEPATHY
       3 ItemAttrBonus DEFENSE 3
     }
-    maxUpgrades = 2
+    maxUpgrades = 1
 	storageIds = {"equipment"}
 	equipedEffect = { POISON_RESISTANT }
   }
@@ -1140,7 +1140,7 @@ End
     price = 40
     modifiers = {
       PARRY 2
-      DEFENSE 1
+      DEFENSE 2
     }
     genPrefixes = {
 	  2 SpellId "BONUS_regeneration"


### PR DESCRIPTION
Adjusts Venorack armor to Iron DEFENSE levels and strips a glyph slot, as I commented on Discord.  (I'd prefer to use glyphs in Adoxium, Adamantine, or Infernite gear: better base numbers. Not sure why someone would use limited glyphs in Venorack or Iron.)