### PR TITLE
Update immigration.txt

### DIFF
--- a/Mods/Alpha36/A36BonusMod/immigration.txt
+++ b/Mods/Alpha36/A36BonusMod/immigration.txt
@@ -1442,7 +1442,7 @@
         noAuto = true
            initialRecruitment = 7 #Modded
        requirements = {
-          { 1 ExponentialCost "CROPS" 10 5 4 } #Modded
+          { 1 ExponentialCost "GOLD" 10 5 4 } #Modded
         }
       }
 	}
@@ -1934,14 +1934,14 @@
       ids = { "HORSE_CAN_TRAIN" "DONKEY" }
       traits = { NO_LIMIT }
       requirements = {
-        { 1.0 CostInfo "CROPS" 15 } #Modded
+        { 1.0 CostInfo "GOLD" 15 } #Modded
       }
     }
     {
       ids = { "GOAT" }
       traits = { NO_LIMIT INCREASE_POPULATION }
       requirements = {
-        { 1 ExponentialCost "CROPS" 10 5 4 }
+        { 1 ExponentialCost "GOLD" 10 5 4 }
       }
       frequency = 0.1
     }


### PR DESCRIPTION
Patches out the show-stopper aspect of the crops-farming problem by making white-keeper troops cost gold instead.  Not a perfect solution, but ensures being able to access everyone.