### PR TITLE
Fix the farming bug

### DIFF
--- a/Mods/Alpha36/A36BonusMod/creatures.txt
+++ b/Mods/Alpha36/A36BonusMod/creatures.txt
@@ -9740,3 +9740,8 @@ End
 "BONUS_YOUNG_GREEN_DRAGON" modify append {maxLevelIncrease = {MELEE 12} }
 "BONUS_YOUNG_RED_DRAGON" modify append {maxLevelIncrease = {MELEE 12} }
 ####
+
+#Making absolutely sure farming creatures can farm; didn't cause immediately-noticeable errors on my end
+"IMP" modify { permanentEffects = append { CROPS_SKILL 1 } }
+"PESEANT_PLAYER" modify { permanentEffects = append { CROPS_SKILL 1 } }
+"GOBLIN_WORKER" modify { permanentEffects = append { CROPS_SKILL 1 } }

--- a/Mods/Alpha36/A36BonusMod/immigration.txt
+++ b/Mods/Alpha36/A36BonusMod/immigration.txt
@@ -1436,13 +1436,13 @@
     "peseants" modify
 	{
       {
-        ids = { "PESEANT" }
+        ids = { "PESEANT_PLAYER" }
         traits = { WORKER NO_LIMIT NO_EQUIPMENT NO_LEISURE_ZONE }
         keybinding = CREATE_IMP
         noAuto = true
            initialRecruitment = 7 #Modded
        requirements = {
-          { 1 ExponentialCost "GOLD" 10 5 4 } #Modded
+          { 1 ExponentialCost "CROPS" 10 5 4 } #Modded
         }
       }
 	}
@@ -1934,14 +1934,14 @@
       ids = { "HORSE_CAN_TRAIN" "DONKEY" }
       traits = { NO_LIMIT }
       requirements = {
-        { 1.0 CostInfo "GOLD" 15 } #Modded
+        { 1.0 CostInfo "CROPS" 15 } #Modded
       }
     }
     {
       ids = { "GOAT" }
       traits = { NO_LIMIT INCREASE_POPULATION }
       requirements = {
-        { 1 ExponentialCost "GOLD" 10 5 4 }
+        { 1 ExponentialCost "CROPS" 10 5 4 }
       }
       frequency = 0.1
     }

--- a/Mods/Alpha36/A36BonusMod/keeper_creatures.txt
+++ b/Mods/Alpha36/A36BonusMod/keeper_creatures.txt
@@ -55,7 +55,7 @@
 	
 }
 
-"7_goblins" modify { technology = append { "simplistic animations" "magic contraptions" "rock blast" } immigrantGroups = append {"animations"} }
+"7_goblins" modify { technology = append { "simplistic animations" "magic contraptions" "rock blast" } immigrantGroups = append {"animations"} credit = { "WOOD" 2000 "STONE" 10 "IRON" 10 "ADA" 5 "CROPS" 25 } }
 "8_zombies" modify { technology = append { "simplistic animations" "magic contraptions" "rock blast" } immigrantGroups = append {"animations"} }
 "9_cyclops" modify { technology = append { "simplistic animations" "magic contraptions" "rock blast" }
                      immigrantGroups = append {"animations"}


### PR DESCRIPTION
Finally found it.  The problem appears to have been a typo/omission in immigration.txt.

Also issues goblin keepers the starting resource allotment (tough to start farming without crops) and ensures that imps and other such workers all get their crops.

Since this fixes Less-Evil keepers not having the ability to raise crops, it also reverts the patch-around to hire peasants and farm animals using gold.