### PR TITLE
Light it up

### DIFF
--- a/Mods/Alpha36/A36BonusMod/items.txt
+++ b/Mods/Alpha36/A36BonusMod/items.txt
@@ -408,7 +408,7 @@ End
       viewId = { "dwarf_beer" }
       name = "dwarven beer"
       weight = 0.3
-      description = "Permanently increases your attack by 1, but makes you insane and halucinate for a while in exchange."
+      description = "Permanently increases your attack by 1, but makes you insane and hallucinate for a while in exchange."
       uses = 1
       price = 100
       effect = { IncreaseAttr DAMAGE 1 Lasting INSANITY Lasting HALLU }
@@ -1268,7 +1268,7 @@ End
  "BONUS_InfLongSpear"
     {
       viewId = { "infernite_spear" }
-	  equipedViewId = { "infernite_spear_v" }
+	  equipedViewId = { "infernite_steel_spear_v" }
       shortName = "spear"
       name = "infernite long spear"
       itemClass = WEAPON

--- a/Mods/Alpha36/A36BonusMod/tiles.txt
+++ b/Mods/Alpha36/A36BonusMod/tiles.txt
@@ -456,7 +456,7 @@
   { viewId = "infernite_spiked_mace_v" symbol = ")" color = ColorId RED weaponOrigin = {13 13} }
   { viewId = "infernite_battle_axe_v" symbol = ")" color = ColorId RED weaponOrigin = {11 14} }
   { viewId = "infernite_war_axe_v" symbol = ")" color = ColorId RED weaponOrigin = {11 14} }
-  { viewId = "infernite_spear_v" symbol = "/" color = ColorId RED weaponOrigin = {14 15} }
+  { viewId = "infernite_steel_spear_v" symbol = "/" color = ColorId RED weaponOrigin = {14 15} }
   { viewId = "infernite_warhammer_v" symbol = ")" color = ColorId GREEN  weaponOrigin = {9 16} }
   { viewId = "blood_sword_v" symbol = ")" color = ColorId RED weaponOrigin = {10 16} }
   { viewId = "poison_sword_v" symbol = ")" color = ColorId GREEN weaponOrigin = {10 16} }


### PR DESCRIPTION
Fix a typo in sprite-linkage so folks wielding an infernite longspear don't pull out a gravestone.

(And fix a typo in dwarven beer's description.)