### PR TITLE
Add additional fairy hideyholes and exotic ores to z-level exploration

### DIFF
--- a/Mods/Alpha36/A36BonusMod/enemies.txt
+++ b/Mods/Alpha36/A36BonusMod/enemies.txt
@@ -3555,6 +3555,105 @@
   "BONUS_ROYAL_DUNGEON99" inherit "BONUS_ROYAL_DUNGEON_TYPE_4" { settlement = append { inhabitants = append { fighters = append { baseLevelIncrease = { MELEE 125 } } } } }
 ####################################################################
 
+###
+#CSeven trying to make fairies more commonplace (feels like they're Illusia, rescue the Demon Fairy from the Abominations, or None)
+#Fairies get pretty powerful if converted, so no need to have them repopulate
+###
+
+"BONUS_VEN_FAIRIES" #shamelessly rip off vanilla Adamantine Golems, but helps with syntax.
+#Took until z11 to have these folks show up in testing, but they were only eligible to show up at z5 and below.
+#In any event, Venorack in quantity *probably* isn't going to overpower everyone.
+{
+  settlement = {
+    type = Builtin VAULT "DUNGEON"
+    inhabitants = {
+      fighters = {
+        count = {2 3}
+        all = {
+		1 "BONUS_DARK_FAIRY"
+		3 "BONUS_EARTH_FAIRY"
+		}
+      }
+    }
+    tribe = ANT
+    race = "underground fairies"
+    dontConnectCave = true
+    surroundWithResources = 3
+    extraResources = "VENORACK_ORE"
+	}
+	
+	#Need this block because the fairies might decide to just come after Keepers (check their entry in zlevels: 30% chance to go Hostile)
+	behaviour = {
+	minPopulation = 0
+    minTeamSize = 1
+	attackBehaviour = StealGold
+    ransom = 0.5 80
+	}
+}
+
+"BONUS_ADOXIUM_FAIRIES"
+{
+settlement = {
+    type = Builtin VAULT "DUNGEON"
+    inhabitants = {
+      fighters = {
+        count = {3 5}
+        all = {
+		2 "BONUS_DARK_FAIRY" #Living next to all this adoxium hasn't done the poor fairy much good
+		3 "BONUS_EARTH_FAIRY"
+		1 "BONUS_DEMON_FAIRY" #Living next to all this adoxium REALLY hasn't done this poor fairy much good at all!
+		1 "BONUS_MAGIC_FAIRY" #Adoxium may be named for the Evil God, but it IS good for magic...
+		}
+      }
+    }
+    tribe = ANT
+    race = "underground fairies"
+    dontConnectCave = true
+    surroundWithResources = 2
+    extraResources = "ADOXIUM_ORE"
+	}
+	
+	#Need this block because the fairies might decide to just come after Keepers (check their entry in zlevels: 50% chance to go Hostile)
+	behaviour = {
+	minPopulation = 0
+    minTeamSize = 1
+	attackBehaviour = StealGold
+    ransom = 0.5 80
+	}
+
+}
+
+"BONUS_INF_FAIRIES"
+{
+settlement = {
+    type = Builtin VAULT "DUNGEON"
+    inhabitants = {
+      fighters = {
+        count = {3 5}
+        all = {
+		3 "BONUS_FIRE_FAIRY" #It's burny metal! Yay!
+		1 "BONUS_EARTH_FAIRY"
+		}
+      }
+    }
+    tribe = ANT
+    race = "underground fairies"
+    dontConnectCave = true
+    surroundWithResources = 2
+    extraResources = "INFERNITE_ORE"
+	}
+	
+	#Need this block because the fairies might decide to just come after Keepers (check their entry in zlevels: 10% chance to go Hostile)
+	behaviour = {
+	minPopulation = 0
+    minTeamSize = 1
+	attackBehaviour = StealGold
+    ransom = 0.5 80
+	}
+
+}
+
+
 ###########################
 #Ideas for future villains#
 ###########################

--- a/Mods/Alpha36/A36BonusMod/enemies.txt
+++ b/Mods/Alpha36/A36BonusMod/enemies.txt
@@ -3562,7 +3562,7 @@
 
 "BONUS_VEN_FAIRIES" #shamelessly rip off vanilla Adamantine Golems, but helps with syntax.
 #Took until z11 to have these folks show up in testing, but they were only eligible to show up at z5 and below.
-#In any event, Venorack in quantity *probably* isn't going to overpower everyone.
+#(Further testing demonstrated that 3 piles per appearance is overkill.)
 {
   settlement = {
     type = Builtin VAULT "DUNGEON"
@@ -3578,16 +3578,16 @@
     tribe = ANT
     race = "underground fairies"
     dontConnectCave = true
-    surroundWithResources = 3
+    surroundWithResources = 2
     extraResources = "VENORACK_ORE"
 	}
 	
 	#Need this block because the fairies might decide to just come after Keepers (check their entry in zlevels: 30% chance to go Hostile)
 	behaviour = {
 	minPopulation = 0
-    minTeamSize = 1
+    	minTeamSize = 1
 	attackBehaviour = StealGold
-    ransom = 0.5 80
+    	ransom = 0.5 80
 	}
 }
 
@@ -3616,9 +3616,9 @@ settlement = {
 	#Need this block because the fairies might decide to just come after Keepers (check their entry in zlevels: 50% chance to go Hostile)
 	behaviour = {
 	minPopulation = 0
-    minTeamSize = 1
+    	minTeamSize = 1
 	attackBehaviour = StealGold
-    ransom = 0.5 80
+    	ransom = 0.5 80
 	}
 
 }
@@ -3646,7 +3646,7 @@ settlement = {
 	#Need this block because the fairies might decide to just come after Keepers (check their entry in zlevels: 10% chance to go Hostile)
 	behaviour = {
 	minPopulation = 0
-    minTeamSize = 1
+    	minTeamSize = 1
 	attackBehaviour = StealGold
     ransom = 0.5 80
 	}

--- a/Mods/Alpha36/A36BonusMod/zlevels.txt
+++ b/Mods/Alpha36/A36BonusMod/zlevels.txt
@@ -181,7 +181,31 @@
     }
     minDepth = 12
   }
+
+#Modded Underground Fairy levels
+ {
+	type = FullZLevel {
+      	enemy = "BONUS_VEN_FAIRIES"
+      	attackChance = 0.3
+    	}
+	minDepth = 3 #Venorack is available at z3, so a huge pile of it with fairy guardians is too
 }
+{
+	type = FullZLevel {
+     	enemy = "BONUS_ADOXIUM_FAIRIES"
+      	attackChance = 0.5 #Living next to large quantities of adoxium may unhinge fair folk...
+      	}
+	minDepth = 12 #Adoxium starts at z12
+}
+{
+	type = FullZLevel {
+	enemy = "BONUS_INF_FAIRIES"
+      	attackChance = 0.1 #Fire fairies are more content to enjoy their infernite
+     	}
+	minDepth = 12
+}
+
+} #Hey, gang, this close-bracket ends the list of generic z-levels. Easy to miss, and breaks the whole mod if you do. Generic z-levels go ABOVE this bracket!
 
 # White and dark keepers (modded)
 # Here come levels specific to white keepers

--- a/Mods/Alpha36/A36BonusMod/zlevels.txt
+++ b/Mods/Alpha36/A36BonusMod/zlevels.txt
@@ -105,9 +105,10 @@
         # Total no of creatures on this level. All are hostile
         count = {10 11}
         all = {
-          # The number is the weight, i.e. rats are twice as many as elementals
-          2 "RAT"
-          1 "WATER_ELEMENTAL"
+          # The number is the weight, i.e. rats are three times more likely than water fairies
+          3 "RAT"
+          2 "WATER_ELEMENTAL"
+	  1 "BONUS_WATER_FAIRY"
         }
       }
     }


### PR DESCRIPTION
Idea here is to increase the amounts of fairies and exotic ores available in BonusMod.  Currently, fairies are pretty much Illusia, the one-off from the Vulture Abominations, and that's it; exotic ores, well, I've never found any Venorack to mine before testing this mod, and Adoxium & Infernite can be depressingly tough to come by.

I'd like to also add Water Fairies to water z-levels, and can include that in this PR if desired.  Was going to put Air and Light (possibly Electric as well) fairies high up the mountain, but haven't had luck getting biomes.txt to accept the modify-append.