### PR TITLE
Update creatures.txt

### DIFF
--- a/Mods/Alpha36/A36BonusMod/creatures.txt
+++ b/Mods/Alpha36/A36BonusMod/creatures.txt
@@ -5892,7 +5892,7 @@ End
       body = {
         type = Humanoid MEDIUM
         intrinsicAttacks = {
-          ARM {{{ Intrinsic { "claws_attack" } "claws" 10 { attackType = HIT attackMsg = CLAW }}} }
+          ARM {{isExtraAttack = true itemType = {Intrinsic { "claws_attack" } "claws" 10 { attackType = HIT attackMsg = CLAW }} }}
         }
       }
       gender = FEMALE


### PR DESCRIPTION
Makes the lion queen's claw attack available alongside any weapon she might have equipped (say, after being converted to a Keeper's service).  She's got better DEF and the intrinsic speed boost; this should make her more competitive with regenerating & triple-attack, but low-DEF, werewolves.