### PR TITLE
Magic Metal Conversion

### DIFF
--- a/Mods/Alpha36/A36BonusMod/keeper_creatures.txt
+++ b/Mods/Alpha36/A36BonusMod/keeper_creatures.txt
@@ -9,20 +9,20 @@
     immigrantGroups = append {"dark_knight_modded" "neutral_allies" "dark_allies_extended" }
     technology = append { "simplistic animations" "magic contraptions" "rock blast" "combat succubus" "advanced smithy" "minotaur mutation" "cyclops mutation" }
     initialTech = { "iron working" }
-    workshopGroups = append { "basic_Bonus_Mod"   "techBooks" "fell armory" }
+    workshopGroups = append { "basic_Bonus_Mod"   "techBooks" "fell armory" "Magic metal conversion" }
     description = "(Challenge) The dark knight keeper is better at melee combat but worse at spell casting."
 	credit = { "WOOD" 2000 "STONE" 10 "IRON" 10 "ADA" 5 "CROPS" 25 }
   }
 #Dark mages come after dark knights as sometimes bits of the GUI get duplicated the other way round.
 "1_dark_mage" modify {
     immigrantGroups = append {"dark_keeper_modded" "neutral_allies" "dark_allies_extended" }
-    technology = append { "simplistic animations" "magic contraptions" "dragon taming" "demonic alliance" "rock blast" "combat succubus"}
+    technology = append { "simplistic animations" "magic contraptions" "dragon taming" "demonic alliance" "rock blast" "combat succubus" "Magic metal conversion" }
     workshopGroups = append { "basic_Bonus_Mod" "techBooks" }
 	credit = { "WOOD" 2000 "STONE" 10 "IRON" 10 "ADA" 5 "CROPS" 25 }
   }
 "3_white_knight" modify {
     immigrantGroups = append { "white_keeper_modded" "neutral_allies" "white_allies_extended" }
-    technology = append { "simplistic animations" "magic contraptions" "legendary heroes" "royal jewellery" "unicorn taming" "rock blast" "advanced smithy" }
+    technology = append { "simplistic animations" "magic contraptions" "legendary heroes" "royal jewellery" "unicorn taming" "rock blast" "advanced smithy" "Magic metal conversion" }
     workshopGroups = append { "white knights workshop" "basic_Bonus_Mod" "law armory" }
     description = "(Hard) Be on the side of the good!"
 	credit = { "WOOD" 2000 "STONE" 10 "IRON" 10 "ADA" 5 "CROPS" 25 }
@@ -55,7 +55,7 @@
 	
 }
 
-"7_goblins" modify { technology = append { "simplistic animations" "magic contraptions" "rock blast" } immigrantGroups = append {"animations"} credit = { "WOOD" 2000 "STONE" 10 "IRON" 10 "ADA" 5 "CROPS" 25 } }
+"7_goblins" modify { technology = append { "simplistic animations" "magic contraptions" "rock blast" } workshopGroups = append {"Magic metal conversion" } immigrantGroups = append {"animations"} credit = { "WOOD" 2000 "STONE" 10 "IRON" 10 "ADA" 5 "CROPS" 25 } }
 "8_zombies" modify { technology = append { "simplistic animations" "magic contraptions" "rock blast" } immigrantGroups = append {"animations"} }
 "9_cyclops" modify { technology = append { "simplistic animations" "magic contraptions" "rock blast" }
                      immigrantGroups = append {"animations"}

--- a/Mods/Alpha36/A36BonusMod/workshops_menu.txt
+++ b/Mods/Alpha36/A36BonusMod/workshops_menu.txt
@@ -640,3 +640,18 @@
 	{{ "BONUS_AdaLongSpear"}          24       "ADA" 25 "advanced smithy"}
 	}
  }
+##
+#Making Venorack, etc compatible with alchemical conversion
+##
+
+"Magic metal conversion"
+{
+	"LABORATORY"
+	{
+		{{ "GoldPiece"}                           5        "VEN"   2      "alchemical conversion"}
+		{{ "GoldPiece"}                           5        "INFERNITE"   1       "alchemical conversion"}
+		{{ "GoldPiece"}                           5        "ADA"   1       "alchemical conversion"}
+		{{ "VenOre"}                              5        "GOLD"  1	     "alchemical conversion"}
+		{{ "InfOre"}                              5        "GOLD"  2      "alchemical conversion"}
+	}
+}


### PR DESCRIPTION
Allows baseline and gobbo keepers to convert magic metals (except adoxium) to and from gold.  Helps deal with resource shorfalls and gluts; BM-specific keepers are already able to do so, not sure if that's supposed to be an advantage of playing a BM keeper.