### PR TITLE
Update creatures.txt

### DIFF
--- a/Mods/Alpha36/A36BonusMod/creatures.txt
+++ b/Mods/Alpha36/A36BonusMod/creatures.txt
@@ -3701,6 +3701,9 @@ End
 	DIGGING 50
 	FORGE 35
   }
+  permanentEffects = append {
+	NO_FRIENDLY_FIRE 1 #Earth Blast is apparently very good at hitting friendlies and causing infighting?
+  }
   name = {
 	name = "earth fairy"
 	pluralName = "fairies"


### PR DESCRIPTION
Gives Earth Fairies NO_FRIENDLY_FIRE due to report that they've been hitting friendlies with earth blast: results in infighting and casualties whenever they're used in a group.