### PR TITLE
Korija2029's fixed immigration.txt

### DIFF
--- a/Mods/Alpha36/A36BonusMod/immigration.txt
+++ b/Mods/Alpha36/A36BonusMod/immigration.txt
@@ -1800,7 +1800,7 @@
       traits = { FIGHTER }
       frequency = 0.7
       requirements = {
-        { 0.1 AttractionInfo 1 {FurnitureType "TRAINING_IRON"}}
+        { 0.1 AttractionInfo 1 {FurnitureType "TRAINING_IRON_HUMAN"}}
       }
       specialTraits = {
         { 0.05 { SpecialAttr DAMAGE 8 HatedBy HATE_DRAGONS }}
@@ -1819,7 +1819,7 @@
       traits = { FIGHTER }
       frequency = 0.3
       requirements = {
-        { 0.1 AttractionInfo 1 {FurnitureType "BOOKCASE_WOOD"}}
+        { 0.1 AttractionInfo 1 {FurnitureType "BOOKCASE_WOOD_HUMAN"}}
         { 0.1 TechId "worship"}
         { 0.0 MinTurnRequirement 500 }
       }
@@ -1835,7 +1835,7 @@
       traits = { FIGHTER }
       frequency = 0.3
       requirements = {
-        { 0.1 AttractionInfo 1 {FurnitureType "BOOKCASE_WOOD"}}
+        { 0.1 AttractionInfo 1 {FurnitureType "BOOKCASE_WOOD_HUMAN"}}
         { 0.0 MinTurnRequirement 500 }
       }
       specialTraits = {


### PR DESCRIPTION
Shadowing/Korija2029's fixed immigration.txt, allowing White Knight Keepers in BonusMod to recruit generic knights.  Many thanks to them for sorting it out.