### PR TITLE
Startup fixes

### DIFF
--- a/Mods/Alpha37/A37BonusMod/enemies.txt
+++ b/Mods/Alpha37/A37BonusMod/enemies.txt
@@ -860,6 +860,7 @@
 ###############################
 "BONUS_BATTLEFIELD"
 {
+  biome = "GRASSLAND"
   settlement = {
     type = Builtin CASTLE2 "BONUS_BATTLEFIELD"
     tribe = MONSTER


### PR DESCRIPTION
Battlefield:
Adding a biome here seems to have fixed the show-off battlefields from crashing during campaign startup (affected lawful keepers, Peasants in particular).  Still getting other crashes though, so Draft.