### PR TITLE
Venorack for Absorbers & Peasants

### DIFF
--- a/Mods/Alpha36/A36BonusMod/keeper_creatures.txt
+++ b/Mods/Alpha36/A36BonusMod/keeper_creatures.txt
@@ -175,7 +175,7 @@
   zLevelGroups = { "basic" "evil" "lawful" }
   initialTech = { "sorcery" }
   buildingGroups = { "absorber" }
-  workshopGroups = { "basic" "crossbows" "bows" "gnomes" "morgue" "absorber" }
+  workshopGroups = { "basic" "basic_Bonus_Mod" "crossbows" "bows" "gnomes" "morgue" "absorber" }
   description = "The absorber is a creature that can learn forms, shape shift and absorb technologies of fallen foes. Warnining: This creature cannot build, recruit, cut or dig until it has learnt those concepts by absorbing them after killing things."
   minionTraits = { LEADER WORKER FIGHTER NO_LIMIT }
   flags = { "abomination_upgrades" }
@@ -201,7 +201,7 @@
   zLevelGroups = { "basic" "evil" "lawful" }
   initialTech = { "sorcery" "iron working" "archery" }
   buildingGroups = { "outcasts" }
-  workshopGroups = { "basic" "crossbows" "bows" "gnomes" "morgue_outcasts" }
+  workshopGroups = { "basic" "basic_Bonus_Mod" "crossbows" "bows" "gnomes" "morgue_outcasts" }
   description = "'Peasants' is community of outcasts with the ability to unite the creatures and technologies of gnomes, goblins, warlocks, undead and knights."
   minionTraits = { LEADER WORKER NO_LIMIT }
   maxPopulation = 100


### PR DESCRIPTION
Gives Absorber & Peasants access to the BonusMod forge group (so venorack is usable).  Not sure if the other groups are intended to not-have Venorack usage.