### PR TITLE
Crops credit for lawful knight

### DIFF
--- a/Mods/Alpha36/A36Farming/keeper_creatures.txt
+++ b/Mods/Alpha36/A36Farming/keeper_creatures.txt
@@ -9,6 +9,11 @@
 	credit = { "CROPS" 25 }
  }
 
+"3_white_knight" modify {
+	credit = { "CROPS" 25 }
+	#No farm_animals as white_knight gets pop-cap increasing animals via gold, courtesy of Vanilla.
+}
+
 "7_goblins" modify {
     immigrantGroups = append {"farm_animals" }
 	credit = { "CROPS" 25 }


### PR DESCRIPTION
Lawful knight was missing a crops credit: fixed.