### PR TITLE
Add NaxSol as contributor to license folder

### DIFF
--- a/Mods/KeeperRL_1.0_Release/10VanillaRetiles/details.txt
+++ b/Mods/KeeperRL_1.0_Release/10VanillaRetiles/details.txt
@@ -12,6 +12,11 @@ prevent other parties from claiming ownership of the tiles and
 relicensing the work under their own terms.
 _____________________________________________________________
 
+_______________________________________
+Additional tiles have been contributed by NaxSol, likewise under GPL,
+for the community's use, 14th May 2026.
+_______________________________________
+
 Note: All Softmonster mods are licensed under GNU GENERAL PUBLIC LICENSE
 (especially for use by Michal if possible).
 I just want to improve the game for everyone.


### PR DESCRIPTION
Adds a note that NaxSol has contributed sprites.  For practical purposes, the PRs and merge logs should allow differentiating whose sprites are whose if that becomes a problem.